### PR TITLE
Pull latest from Honeycomb; 1.8.3 --> 2.1.0 (#4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,13 @@ executors:
         default: "12"
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
-
+        environment:
+          PGUSER: root
+          PGDATABASE: circle_test
+      - image: circleci/postgres:9-alpine-ram
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
 jobs:
   test_libhoney:
     parameters:
@@ -18,13 +24,16 @@ jobs:
       npm_install:
         type: string
         default: "ci"
+      npm_task:
+        type: string
+        default: "test"
     executor:
       name: node
       nodeversion: "<< parameters.nodeversion >>"
     steps:
       - checkout
       - run: npm << parameters.npm_install >>
-      - run: npm test
+      - run: npm << parameters.npm_task >>
 
   publish:
     docker:
@@ -35,16 +44,15 @@ jobs:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
-      - run: npm run lint
       - run: npm publish
 
 workflows:
   build-libhoney:
     jobs:
       - test_libhoney:
-          name: test_node891
-          nodeversion: "8.9.1"
-          npm_install: "i"
+          name: lint
+          nodeversion: "12"
+          npm_task: "run lint"
           filters:
               branches:
                 only: /.*/
@@ -54,6 +62,8 @@ workflows:
           name: test_node9
           nodeversion: "9"
           npm_install: "i"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -63,6 +73,8 @@ workflows:
           name: test_node1000
           nodeversion: "10.0.0"
           npm_install: "i"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -71,6 +83,8 @@ workflows:
       - test_libhoney:
           name: test_node10
           nodeversion: "10"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -79,6 +93,8 @@ workflows:
       - test_libhoney:
           name: test_node11
           nodeversion: "11"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -87,6 +103,8 @@ workflows:
       - test_libhoney:
           name: test_node12
           nodeversion: "12"
+          requires:
+            - lint
           filters:
               branches:
                 only: /.*/
@@ -94,11 +112,11 @@ workflows:
                 only: /.+/
       - publish:
           requires:
-            - test_node891
             - test_node9
             - test_node1000
             - test_node10
             - test_node11
+            - test_node12
           filters:
               branches:
                 ignore: /.*/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "extends": ["eslint:recommended"],
   "parserOptions": {
-    "ecmaVersion": 2015
+    "ecmaVersion": 2018
   },
   "rules": {
     "no-console": "off",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package makes it easy to instrument your Express/NodeJS application to send
 
 ## Dependencies
 
-- **Node 8+** - relies on Node 8's `async_hooks`
+- **Node 10+**
 
 ## Contributions
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -11,6 +11,14 @@ const path = require("path"),
 
 let apiImpl;
 
+function mapFieldsToApp(map) {
+  let mapped = {};
+  for (const k of Object.getOwnPropertyNames(map)) {
+    mapped[schema.customContext(k)] = map[k];
+  }
+  return mapped;
+}
+
 module.exports = {
   configure(opts = {}) {
     if (apiImpl) {
@@ -42,6 +50,8 @@ module.exports = {
   },
 
   TRACE_HTTP_HEADER: propagation.TRACE_HTTP_HEADER,
+  AMAZON_TRACE_HTTP_HEADER: propagation.AMAZON_TRACE_HTTP_HEADER,
+  REQUEST_ID_HTTP_HEADER: propagation.REQUEST_ID_HTTP_HEADER,
   marshalTraceContext: propagation.marshalTraceContext,
   unmarshalTraceContext: propagation.unmarshalTraceContext,
 
@@ -103,19 +113,40 @@ module.exports = {
     }
   },
 
+  // next major bump should change this to prefix keys with `app.`
   addContext(map) {
     return apiImpl.addContext(map);
   },
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
     return apiImpl.removeContext(key);
   },
+
+  // DEPRECATED
+  // original api for trace-level (auto-propagated) context.
+  // next major bump will remove this.  No replacement for `.customContext.remove`,
+  // and `.addTraceContext` below will the way to handle `.customContext.add`
   customContext: {
     add(key, val) {
-      apiImpl.addContext({ [schema.customContext(key)]: val });
+      let map;
+
+      if (val === undefined && typeof key === "object") {
+        map = key;
+      } else {
+        map = { [key]: val };
+      }
+
+      return apiImpl.addTraceContext(mapFieldsToApp(map));
     },
     remove(key) {
-      apiImpl.removeContext(schema.customContext(key));
+      return apiImpl.removeTraceContext(schema.customContext(key));
     },
+  },
+
+  addTraceContext(map) {
+    return apiImpl.addTraceContext(mapFieldsToApp(map));
   },
 
   // a couple of useful functions for either forcing a function to run within a trace, or

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
 const path = require("path"),
-  event = require("."),
+  api = require("."),
   schema = require("../schema"),
   tracker = require("../async_tracker"),
   propagation = require("../propagation"),
@@ -10,11 +10,11 @@ const path = require("path"),
 jest.mock("../deterministic_sampler");
 
 beforeEach(() =>
-  event.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
+  api.configure({ impl: "libhoney-event", transmission: "mock", writeKey: "abc123" })
 );
-afterEach(() => event._resetForTesting());
+afterEach(() => api._resetForTesting());
 test("libhoney default config", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(honey.transmission.constructorArg.apiHost).toBe("https://api.honeycomb.io");
   expect(honey.transmission.constructorArg.dataset).toBe("nodejs");
   expect(honey.transmission.constructorArg.writeKey).toBe("abc123");
@@ -24,10 +24,10 @@ test("libhoney default config", () => {
 });
 
 test("startTrace starts tracking and creates an initial event, finishTrace sends it", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
@@ -36,20 +36,20 @@ test("startTrace starts tracking and creates an initial event, finishTrace sends
   let context = tracker.getTracked();
   expect(context).not.toBeUndefined();
 
-  // the stack consists solely of the request's event
-  expect(context.stack).toEqual([requestPayload]);
+  // the stack consists solely of the root span
+  expect(context.stack).toEqual([rootSpan]);
   // and it should have these properties
-  expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
-  let traceId = requestPayload[schema.TRACE_ID];
+  expect(rootSpan.payload[schema.EVENT_TYPE]).toBe("source");
+  let traceId = rootSpan.payload[schema.TRACE_ID];
   expect(traceId).not.toBeUndefined();
-  let startTime = requestPayload.startTime;
+  let startTime = rootSpan.startTime;
   expect(startTime).not.toBeUndefined();
 
   // libhoney shouldn't have been told to send anything yet
   expect(honey.transmission.events).toEqual([]);
 
   // finish the request
-  event.finishTrace(requestPayload);
+  api.finishTrace(rootSpan);
   expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
 
   // libhoney should have been told to send one event
@@ -67,18 +67,18 @@ test("startTrace starts tracking and creates an initial event, finishTrace sends
 });
 
 test("sample rates are propagated", () => {
-  event._resetForTesting();
-  event.configure({
+  api._resetForTesting();
+  api.configure({
     impl: "libhoney-event",
     transmission: "mock",
     writeKey: "abc123",
     sampleRate: 10,
   });
 
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
   expect(tracker.getTracked()).toBeUndefined(); // context should be empty initially
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
@@ -88,19 +88,19 @@ test("sample rates are propagated", () => {
   expect(context).not.toBeUndefined();
 
   // the stack consists solely of the request's event
-  expect(context.stack).toEqual([requestPayload]);
+  expect(context.stack).toEqual([rootSpan]);
   // and it should have these properties
-  expect(requestPayload[schema.EVENT_TYPE]).toBe("source");
-  let traceId = requestPayload[schema.TRACE_ID];
+  expect(rootSpan.payload[schema.EVENT_TYPE]).toBe("source");
+  let traceId = rootSpan.payload[schema.TRACE_ID];
   expect(traceId).not.toBeUndefined();
-  let startTime = requestPayload.startTime;
+  let startTime = rootSpan.startTime;
   expect(startTime).not.toBeUndefined();
 
   // libhoney shouldn't have been told to send anything yet
   expect(honey.transmission.events).toEqual([]);
 
   // finish the request
-  event.finishTrace(requestPayload);
+  api.finishTrace(rootSpan);
   expect(tracker.getTracked()).toBeUndefined(); // context should be cleared
 
   // libhoney should have been told to send one event
@@ -124,22 +124,22 @@ describe("sampler hook", () => {
         shouldSample: true,
         sampleRate: 123,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
+      let eventPayload = api.startTrace({});
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(0);
 
-      event.finishTrace(eventPayload);
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
     });
 
     test("it does not enqueue event if shouldSample is false", () => {
@@ -147,19 +147,19 @@ describe("sampler hook", () => {
         shouldSample: false,
         sampleRate: 123,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
     });
 
     test("it does not enqueue event if invalid samplerHook provided", () => {
@@ -167,19 +167,19 @@ describe("sampler hook", () => {
         foo: "bar",
         baz: false,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(mockSamplerHook).toHaveBeenCalledTimes(1);
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
     });
 
     test("it falls back to deterministicSampler with sampleRate if non-function samplerHook provided", () => {
@@ -189,8 +189,8 @@ describe("sampler hook", () => {
         sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
@@ -198,8 +198,8 @@ describe("sampler hook", () => {
         samplerHook: "I am invalid as I am not a function",
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
       expect(deterministicSampler).toHaveBeenCalledWith(12345);
@@ -210,18 +210,18 @@ describe("sampler hook", () => {
         shouldSample: true,
         sampleRate: 999,
       }));
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         samplerHook: mockSamplerHook,
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
-      expect(event._apiForTesting().honey.transmission.events[0].sampleRate).toEqual(999);
+      expect(api._apiForTesting().honey.transmission.events[0].sampleRate).toEqual(999);
     });
   });
 
@@ -233,21 +233,21 @@ describe("sampler hook", () => {
         sampleRate: 999,
       }));
       deterministicSampler.mockImplementation(mockSamplerHook);
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
         sampleRate: 123,
       });
 
-      let eventPayload = event.startTrace();
+      let eventPayload = api.startTrace();
 
       // initialisation
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
       expect(deterministicSampler).toHaveBeenCalledWith(123);
 
-      event.finishTrace(eventPayload);
+      api.finishTrace(eventPayload);
 
       // verify initiliser not called again
       expect(deterministicSampler).toHaveBeenCalledTimes(1);
@@ -258,188 +258,190 @@ describe("sampler hook", () => {
 
   describe("if neither a samplerHook nor sampleRate given", () => {
     test("send all events", () => {
-      event._resetForTesting();
-      event.configure({
+      api._resetForTesting();
+      api.configure({
         impl: "libhoney-event",
         transmission: "mock",
         writeKey: "abc123",
       });
 
-      let eventPayload = event.startTrace({});
-      event.finishTrace(eventPayload);
+      let eventPayload = api.startTrace({});
+      api.finishTrace(eventPayload);
 
-      expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+      expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
     });
   });
 });
 
 test("ending events out of order isn't allowed", () => {
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
   let context = tracker.getTracked();
 
-  expect(context.stack).toEqual([requestPayload]);
+  expect(context.stack).toEqual([rootSpan]);
 
-  let event2Payload = event.startSpan({
+  let span2 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  let event3Payload = event.startSpan({
+  let span3 = api.startSpan({
     [schema.EVENT_TYPE]: "source3",
     [schema.TRACE_SPAN_NAME]: "name3",
   });
-  expect(context.stack).toEqual([requestPayload, event2Payload, event3Payload]);
+  expect(context.stack).toEqual([rootSpan, span2, span3]);
 
-  // if we end event2Payload from the stack, we should also remove event3Payload.
-  event.finishSpan(event2Payload);
-  expect(context.stack).toEqual([requestPayload]);
+  // if we end span2 from the stack, we should also remove span3.
+  api.finishSpan(span2);
+  expect(context.stack).toEqual([rootSpan]);
 
-  // if we finish event3 now, nothing should happen to the stack
-  event.finishSpan(event3Payload);
-  expect(context.stack).toEqual([requestPayload]);
+  // if we finish span3 now, nothing should happen to the stack
+  api.finishSpan(span3);
+  expect(context.stack).toEqual([rootSpan]);
 });
 
 test("sub-events can opt to rollup count/duration into request events", () => {
-  let requestPayload = event.startTrace({
+  const honey = api._apiForTesting().honey;
+
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
 
-  let eventPayload = event.startSpan({
+  let subSpan = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(eventPayload, "rollup");
+  api.finishSpan(subSpan, "rollup");
 
-  let durationMS = eventPayload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(1);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS);
+  let durationMS = JSON.parse(honey.transmission.events[0].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(1);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS);
 
-  // another event from the same source
-  let event2Payload = event.startSpan({
+  // another span from the same source
+  let span2 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(event2Payload, "rollup");
+  api.finishSpan(span2, "rollup");
 
-  let duration2MS = event2Payload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(2);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
+  let duration2MS = JSON.parse(honey.transmission.events[1].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
 
   // these rollup to the instrumentation/source-level as well:
-  expect(requestPayload["totals.source2.count"]).toBe(2);
-  expect(requestPayload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS);
+  expect(rootSpan.payload["totals.source2.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS);
 
   // one more event from the same source but a different name
-  let event3Payload = event.startSpan({
+  let span3 = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
   });
-  event.finishSpan(event3Payload, "rollup2");
+  api.finishSpan(span3, "rollup2");
 
-  let duration3MS = event3Payload[schema.DURATION_MS];
-  expect(requestPayload["totals.source2.rollup2.count"]).toBe(1);
-  expect(requestPayload["totals.source2.rollup2.duration_ms"]).toBe(duration3MS);
+  let duration3MS = JSON.parse(honey.transmission.events[2].postData)[schema.DURATION_MS];
+  expect(rootSpan.payload["totals.source2.rollup2.count"]).toBe(1);
+  expect(rootSpan.payload["totals.source2.rollup2.duration_ms"]).toBe(duration3MS);
 
   // it doesn't touch the "rollup" rollup
-  expect(requestPayload["totals.source2.rollup.count"]).toBe(2);
-  expect(requestPayload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
+  expect(rootSpan.payload["totals.source2.rollup.count"]).toBe(2);
+  expect(rootSpan.payload["totals.source2.rollup.duration_ms"]).toBe(durationMS + duration2MS);
 
   // but it does get rolled into the instrumentation/source-level rollup:
-  expect(requestPayload["totals.source2.count"]).toBe(3);
-  expect(requestPayload["totals.source2.duration_ms"]).toBe(durationMS + duration2MS + duration3MS);
+  expect(rootSpan.payload["totals.source2.count"]).toBe(3);
+  expect(rootSpan.payload["totals.source2.duration_ms"]).toBe(
+    durationMS + duration2MS + duration3MS
+  );
 });
 
 test("sub-events will get manual tracing fields", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let requestPayload = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.EVENT_TYPE]: "source",
     [schema.TRACE_SPAN_NAME]: "name",
   });
 
-  let eventPayload = event.startSpan({
+  let subSpan = api.startSpan({
     [schema.EVENT_TYPE]: "source2",
     [schema.TRACE_SPAN_NAME]: "name2",
   });
-  event.finishSpan(eventPayload);
-
-  // finish the request
-  event.finishTrace(requestPayload);
+  api.finishSpan(subSpan);
+  api.finishTrace(rootSpan);
 
   // libhoney should have been told to send two events
   expect(honey.transmission.events.length).toBe(2);
 
-  let subEventData = JSON.parse(honey.transmission.events[0].postData);
-  let reqEventData = JSON.parse(honey.transmission.events[1].postData);
+  let subSpanData = JSON.parse(honey.transmission.events[0].postData);
+  let rootSpanData = JSON.parse(honey.transmission.events[1].postData);
 
-  expect(subEventData[schema.TRACE_PARENT_ID]).toBe(reqEventData[schema.TRACE_SPAN_ID]);
-  expect(subEventData[schema.TRACE_ID]).toBe(reqEventData[schema.TRACE_ID]);
-  expect(subEventData[schema.TRACE_SPAN_NAME]).toBe("name2");
+  expect(subSpanData[schema.TRACE_PARENT_ID]).toBe(rootSpanData[schema.TRACE_SPAN_ID]);
+  expect(subSpanData[schema.TRACE_ID]).toBe(rootSpanData[schema.TRACE_ID]);
+  expect(subSpanData[schema.TRACE_SPAN_NAME]).toBe("name2");
 });
 
 describe("custom context", () => {
   test("it should be added to request events", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     let requestData = JSON.parse(honey.transmission.events[0].postData);
     expect(requestData[schema.customContext("testKey")]).toBe("testVal");
   });
 
   test("removing it works too", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
-    event.customContext.remove("testKey");
+    api.customContext.remove("testKey");
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     let requestData = JSON.parse(honey.transmission.events[0].postData);
     expect(requestData[schema.customContext("testKey")]).toBeUndefined();
   });
 
   test("it should be added to subevents sent after it was added", () => {
-    const honey = event._apiForTesting().honey;
+    const honey = api._apiForTesting().honey;
 
-    let requestPayload = event.startTrace({
+    let requestPayload = api.startTrace({
       [schema.EVENT_TYPE]: "source",
       [schema.TRACE_SPAN_NAME]: "name",
     });
 
-    let eventPayload = event.startSpan({
+    let eventPayload = api.startSpan({
       [schema.EVENT_TYPE]: "source2",
       [schema.TRACE_SPAN_NAME]: "name2",
     });
-    event.finishSpan(eventPayload);
+    api.finishSpan(eventPayload);
 
-    event.customContext.add("testKey", "testVal");
+    api.customContext.add("testKey", "testVal");
 
-    let eventPayload2 = event.startSpan({
+    let eventPayload2 = api.startSpan({
       [schema.EVENT_TYPE]: "source3",
       [schema.TRACE_SPAN_NAME]: "name3",
     });
-    event.finishSpan(eventPayload2);
+    api.finishSpan(eventPayload2);
 
     // finish the request
-    event.finishTrace(requestPayload);
+    api.finishTrace(requestPayload);
 
     // libhoney should have been told to send two events
     expect(honey.transmission.events.length).toBe(3);
@@ -463,12 +465,18 @@ describe("custom context", () => {
 });
 
 test("distributed tracing linkage is correct", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let rootSpan = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.TRACE_SPAN_NAME]: "root",
   });
-  let traceId = rootSpan[schema.TRACE_ID];
+  let traceId = rootSpan.payload[schema.TRACE_ID];
+
+  // add some additional context to the root span
+  rootSpan.addContext({ directContext: "direct" });
+  api.addContext({ localContext: "local" });
+  api.customContext.add({ customContext: "custom" });
+  api.addTraceContext({ traceCustomContext: "trace-custom" });
 
   let rootContext = tracker.getTracked();
 
@@ -477,24 +485,26 @@ test("distributed tracing linkage is correct", () => {
   // this little bit of code simulates a downstream service.
   tracker.setTracked(undefined);
   let ctx = propagation.unmarshalTraceContext(marshaledContext);
-  let subserviceRootSpan = event.startTrace(
+  let subserviceRootSpan = api.startTrace(
     {
       [schema.TRACE_SPAN_NAME]: "sub",
     },
     ctx.traceId,
     ctx.parentSpanId
   );
+  const subContext = tracker.getTracked();
+  subContext.traceContext = ctx.customContext;
 
-  let subserviceSubspan = event.startSpan({
+  let subserviceSubspan = api.startSpan({
     [schema.TRACE_SPAN_NAME]: "subspan",
   });
-  event.finishSpan(subserviceSubspan);
-  event.finishTrace(subserviceRootSpan);
+  api.finishSpan(subserviceSubspan);
+  api.finishTrace(subserviceRootSpan);
   // end of downstream service.
 
   // reinstate the root service's context and finish the trace there.
   tracker.setTracked(rootContext);
-  event.finishTrace(rootSpan);
+  api.finishTrace(rootSpan);
 
   // libhoney should have been told to send three events
   expect(honey.transmission.events.length).toBe(3);
@@ -523,21 +533,38 @@ test("distributed tracing linkage is correct", () => {
   s.add(subTraceEventData[schema.TRACE_SPAN_ID]);
   s.add(rootEventData[schema.TRACE_SPAN_ID]);
   expect(s.size).toBe(3);
+
+  // verify that context was/was not propagated
+  expect(rootEventData["directContext"]).toBe("direct");
+  expect(subSpanEventData["directContext"]).toBeUndefined();
+  expect(subTraceEventData["directContext"]).toBeUndefined();
+
+  expect(rootEventData["localContext"]).toBe("local");
+  expect(subSpanEventData["localContext"]).toBeUndefined();
+  expect(subTraceEventData["localContext"]).toBeUndefined();
+
+  expect(rootEventData["app.customContext"]).toBe("custom");
+  expect(subSpanEventData["app.customContext"]).toBe("custom");
+  expect(subTraceEventData["app.customContext"]).toBe("custom");
+
+  expect(rootEventData["app.traceCustomContext"]).toBe("trace-custom");
+  expect(subSpanEventData["app.traceCustomContext"]).toBe("trace-custom");
+  expect(subTraceEventData["app.traceCustomContext"]).toBe("trace-custom");
 });
 
 test("async spans share custom context", () => {
-  const honey = event._apiForTesting().honey;
+  const honey = api._apiForTesting().honey;
 
-  let rootSpan = event.startTrace({
+  let rootSpan = api.startTrace({
     [schema.TRACE_SPAN_NAME]: "root",
   });
 
-  event.customContext.add("custom", "value");
+  api.customContext.add("custom", "value");
 
-  event.startAsyncSpan({}, span => {
-    event.finishSpan(span);
+  api.startAsyncSpan({}, span => {
+    api.finishSpan(span);
   });
-  event.finishTrace(rootSpan);
+  api.finishTrace(rootSpan);
 
   expect(honey.transmission.events.length).toBe(2);
 
@@ -548,27 +575,27 @@ test("async spans share custom context", () => {
 describe("presend hook", () => {
   it("calls the presend hook function if provided", () => {
     const mockPresendHook = jest.fn();
-    event._resetForTesting();
-    event.configure({
+    api._resetForTesting();
+    api.configure({
       impl: "libhoney-event",
       transmission: "mock",
       writeKey: "abc123",
       presendHook: mockPresendHook,
     });
 
-    let eventPayload = event.startTrace({});
+    let eventPayload = api.startTrace({});
 
-    event.finishTrace(eventPayload);
+    api.finishTrace(eventPayload);
 
     expect(mockPresendHook).toHaveBeenCalledTimes(1);
-    expect(event._apiForTesting().honey.transmission.events).toHaveLength(1);
+    expect(api._apiForTesting().honey.transmission.events).toHaveLength(1);
   });
 
   it("doesn't call the presend hook if the event is not being sampled", () => {
     const mockPresendHook = jest.fn();
     const mockSamplerHook = jest.fn(() => ({ shouldSample: false, sampleRate: 1 }));
-    event._resetForTesting();
-    event.configure({
+    api._resetForTesting();
+    api.configure({
       impl: "libhoney-event",
       transmission: "mock",
       writeKey: "abc123",
@@ -576,12 +603,12 @@ describe("presend hook", () => {
       presendHook: mockPresendHook,
     });
 
-    let eventPayload = event.startTrace({});
+    let eventPayload = api.startTrace({});
 
-    event.finishTrace(eventPayload);
+    api.finishTrace(eventPayload);
 
     expect(mockSamplerHook).toHaveBeenCalledTimes(1);
     expect(mockPresendHook).toHaveBeenCalledTimes(0);
-    expect(event._apiForTesting().honey.transmission.events).toHaveLength(0);
+    expect(api._apiForTesting().honey.transmission.events).toHaveLength(0);
   });
 });

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -9,6 +9,7 @@ const libhoney = require("libhoney"),
   instrumentation = require("../instrumentation"),
   deterministicSampler = require("../deterministic_sampler"),
   schema = require("../schema"),
+  Span = require("./span"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   debug = require("debug")(`${pkg.name}:event`);
 
@@ -94,47 +95,58 @@ module.exports = class LibhoneyEventAPI {
 
     tracker.setTracked({
       id,
-      customContext: {},
+      traceContext: {},
       stack: [],
       dataset: dataset || this.defaultDataset,
     });
     return this.startSpan(metadataContext, undefined, parentSpanId);
   }
 
-  finishTrace(ev) {
-    this.finishSpan(ev);
+  finishTrace(span) {
+    this.finishSpan(span);
     tracker.deleteTracked();
   }
 
   startSpan(metadataContext, spanId = uuidv4(), parentId = undefined) {
     let context = tracker.getTracked();
+    if (!context) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      this.askForIssue("no context in startSpan.");
+      return;
+    }
     if (context.stack.length > 0) {
       if (parentId) {
         debug("parentId supplied when there are already spans.. wrong.");
       }
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
     if (!parentId) {
       parentId = context.parentId;
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
-    context.stack.push(eventPayload);
-    return eventPayload;
+    context.stack.push(span);
+    return span;
   }
 
   startAsyncSpan(metadataContext, spanFn) {
     let parentId;
     let spanId = uuidv4();
     let parentContext = tracker.getTracked();
+    if (!parentContext) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      this.askForIssue("no parentContext in startAsyncSpan.");
+      spanFn({});
+      return;
+    }
     if (parentContext.stack.length > 0) {
       parentId = parentContext.stack[parentContext.stack.length - 1][schema.TRACE_SPAN_ID];
     }
@@ -142,29 +154,29 @@ module.exports = class LibhoneyEventAPI {
       parentId = parentContext.parentId;
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: parentContext.id,
-      [schema.TRACE_SPAN_ID]: spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: parentContext.id,
+        [schema.TRACE_SPAN_ID]: spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
 
     let newContext = {
       id: parentContext.id,
       parentId: parentId,
-      customContext: parentContext.customContext,
+      traceContext: parentContext.traceContext,
       dataset: parentContext.dataset,
-      stack: [eventPayload],
+      stack: [span],
     };
 
-    return tracker.callWithContext(() => spanFn(eventPayload), newContext);
+    return tracker.callWithContext(() => spanFn(span), newContext);
   }
 
-  finishSpan(ev, rollup) {
-    debug(`finishing span ${JSON.stringify(ev)}`);
+  finishSpan(span, rollup) {
+    debug(`finishing span ${JSON.stringify(span)}`);
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
@@ -173,30 +185,23 @@ module.exports = class LibhoneyEventAPI {
     }
     if (context.stack.length === 0) {
       // this _really_ shouldn't happen.
-      this.askForIssue("no payload for event we're trying to finish (stack is empty).");
+      this.askForIssue("no payload for span we're trying to finish (stack is empty).");
       return;
     }
-    const idx = context.stack.indexOf(ev);
+    const idx = context.stack.indexOf(span);
     if (idx === -1) {
       // again, this _really_ shouldn't happen.
-      this.askForIssue("no payload for event we're trying to finish (event not found).");
+      this.askForIssue("no payload for span we're trying to finish (span not found).");
       return;
     }
     if (idx !== context.stack.length - 1) {
       // the event we're finishing isn't the most deeply nested one. warn the user.
       this.askForIssue(
-        "finishing an event with unfinished nested events. almost certainly not what we want."
+        "finishing an span with unfinished nested spans. almost certainly not what we want."
       );
     }
 
-    const payload = context.stack[idx];
-
-    const { startTime, startTimeHR } = payload;
-    const duration = process.hrtime(startTimeHR);
-    const durationMs = (duration[0] * 1e9 + duration[1]) / 1e6;
-    payload[schema.DURATION_MS] = durationMs;
-    delete payload.startTime;
-    delete payload.startTimeHR;
+    const payload = context.stack[idx].finalizePayload();
 
     // chop off events after (and including) this one from the stack.
     context.stack = context.stack.slice(0, idx);
@@ -207,16 +212,16 @@ module.exports = class LibhoneyEventAPI {
         if (context.stack.length === 0) {
           debug("no event to rollup into");
         } else {
-          const rootPayload = context.stack[0];
+          const rootPayload = context.stack[0].payload;
           const type = payload[schema.EVENT_TYPE];
 
           // per-rollup rollups
           incr(rootPayload, `totals.${type}.${rollup}.count`);
-          incr(rootPayload, `totals.${type}.${rollup}.duration_ms`, durationMs);
+          incr(rootPayload, `totals.${type}.${rollup}.duration_ms`, payload[schema.DURATION_MS]);
 
           // per-instrumentation rollups
           incr(rootPayload, `totals.${type}.count`);
-          incr(rootPayload, `totals.${type}.duration_ms`, durationMs);
+          incr(rootPayload, `totals.${type}.duration_ms`, payload[schema.DURATION_MS]);
         }
       }
 
@@ -224,9 +229,9 @@ module.exports = class LibhoneyEventAPI {
       const active_instrumentation_count = active_instrumentations.length;
       const ev = this.honey.newEvent();
       ev.dataset = context.dataset;
-      ev.timestamp = new Date(startTime);
+      ev.timestamp = new Date(span.startTime);
       ev.add(payload);
-      ev.add(context.customContext);
+      ev.add(context.traceContext);
       ev.add({
         [schema.INSTRUMENTATIONS]: active_instrumentations,
         [schema.INSTRUMENTATION_COUNT]: active_instrumentation_count,
@@ -260,20 +265,42 @@ module.exports = class LibhoneyEventAPI {
 
   addContext(map) {
     const context = tracker.getTracked();
-    if (!context) {
+    if (!context || context.stack.length === 0) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    Object.assign(context.customContext, map);
+    Object.assign(context.stack[0].payload, map);
   }
 
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
+    const context = tracker.getTracked();
+    if (!context || context.stack.length === 0) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      return;
+    }
+    delete context.stack[0].payload[key];
+  }
+
+  addTraceContext(map) {
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
       return;
     }
-    delete context.customContext[key];
+    Object.assign(context.traceContext, map);
+  }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
+  removeTraceContext(key) {
+    const context = tracker.getTracked();
+    if (!context) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      return;
+    }
+    delete context.traceContext[key];
   }
 
   dumpRequestContext() {

--- a/lib/api/mock.js
+++ b/lib/api/mock.js
@@ -1,14 +1,14 @@
 /* eslint-env node */
-const process = require("process"),
-  path = require("path"),
+const path = require("path"),
   pkg = require(path.join(__dirname, "..", "..", "package.json")),
   tracker = require("../async_tracker"),
-  schema = require("../schema");
+  schema = require("../schema"),
+  Span = require("./span");
 
 module.exports = class MockEventAPI {
   constructor(opts) {
     this.constructorArg = opts;
-    this.customContext = {};
+    this.traceContext = {};
     this.sentEvents = [];
     this.traceId = 0;
   }
@@ -25,63 +25,82 @@ module.exports = class MockEventAPI {
   startSpan(metadataContext, spanId = undefined, parentId = undefined) {
     let context = tracker.getTracked();
     if (context.stack.length > 0) {
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: spanId || ++context.spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: spanId || ++context.spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
-    context.stack.push(eventPayload);
-    return eventPayload;
+    context.stack.push(span);
+    return span;
   }
   startAsyncSpan(metadataContext, spanFn) {
     let parentId;
     let context = tracker.getTracked();
     let spanId = context.spanId + 1000;
     if (context.stack.length > 0) {
-      parentId = context.stack[context.stack.length - 1][schema.TRACE_SPAN_ID];
+      parentId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
     }
 
-    const eventPayload = Object.assign({}, metadataContext, {
-      [schema.TRACE_ID]: context.id,
-      [schema.TRACE_SPAN_ID]: ++spanId,
-      startTime: Date.now(),
-      startTimeHR: process.hrtime(),
-    });
+    const span = new Span(
+      Object.assign({}, metadataContext, {
+        [schema.TRACE_ID]: context.id,
+        [schema.TRACE_SPAN_ID]: ++spanId,
+      })
+    );
     if (parentId) {
-      eventPayload[schema.TRACE_PARENT_ID] = parentId;
+      span.addContext({ [schema.TRACE_PARENT_ID]: parentId });
     }
 
     let newContext = {
       id: context.id,
       spanId,
-      stack: [eventPayload],
+      stack: [span],
     };
 
-    return tracker.callWithContext(() => spanFn(eventPayload), newContext);
+    return tracker.callWithContext(() => spanFn(span), newContext);
   }
 
-  finishSpan(ev, _rollup) {
-    Object.assign(ev, this.customContext, {
-      [schema.DURATION_MS]: 0,
-      [schema.BEELINE_VERSION]: pkg.version,
-    });
+  finishSpan(span, _rollup) {
+    const payload = span.finalizePayload();
+
+    // override this so we don't have to worry about test durations
+    payload[schema.DURATION_MS] = 0;
+
+    payload[schema.BEELINE_VERSION] = pkg.version;
+
     let context = tracker.getTracked();
     // pop it off the stack
-    const idx = context.stack.indexOf(ev);
+    const idx = context.stack.indexOf(span);
     this.eventStack = context.stack.slice(0, idx);
-    this.sentEvents.push(ev);
+    this.sentEvents.push(payload);
   }
+
   addContext(map) {
-    Object.assign(this.customContext, map);
+    let context = tracker.getTracked();
+    Object.assign(context.stack[0], map);
   }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
   removeContext(key) {
-    delete this.customContext[key];
+    let context = tracker.getTracked();
+    delete context.stack[0].payload[key];
+  }
+
+  addTraceContext(map) {
+    Object.assign(this.traceContext, map);
+  }
+
+  // DEPRECATED
+  // next major bump will remove this.  No replacement.
+  removeTraceContext(key) {
+    delete this.traceContext[key];
   }
 
   flush() {

--- a/lib/api/span.js
+++ b/lib/api/span.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+const process = require("process"),
+  schema = require("../schema");
+
+module.exports = class Span {
+  constructor(payload) {
+    this.payload = payload;
+    this.startTime = Date.now();
+    this.startTimeHR = process.hrtime();
+  }
+
+  addContext(map) {
+    Object.assign(this.payload, map);
+  }
+
+  finalizePayload() {
+    let rv = Object.assign({}, this.payload);
+    const duration = process.hrtime(this.startTimeHR);
+    const durationMs = (duration[0] * 1e9 + duration[1]) / 1e6;
+    rv[schema.DURATION_MS] = durationMs;
+    return rv;
+  }
+};

--- a/lib/instrumentation/child_process.js
+++ b/lib/instrumentation/child_process.js
@@ -19,7 +19,7 @@ function wrapExecLike(name, packageVersion) {
         },
         span => {
           if (Array.isArray(args)) {
-            api.addContext({ "exec.args": args });
+            span.addContext({ "exec.args": args });
           }
 
           let argsArray = Array.from(arguments);

--- a/lib/instrumentation/child_process.test.js
+++ b/lib/instrumentation/child_process.test.js
@@ -36,6 +36,7 @@ test("execFile '/bin/echo hi' works", done => {
   child_process.execFile("echo", ["hi"], (error, stdout) => {
     expect(error).toBeNull();
     expect(stdout).toBe("hi\n");
+
     expect(api._apiForTesting().sentEvents.length).toBe(1);
 
     let ev = api._apiForTesting().sentEvents[0];

--- a/lib/instrumentation/express.js
+++ b/lib/instrumentation/express.js
@@ -88,7 +88,7 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
   if (parentTraceId) {
     traceContext.parentSpanId = parentTraceId;
   }
-  let trace = api.startTrace(
+  let rootSpan = api.startTrace(
     {
       [schema.EVENT_TYPE]: "express",
       [schema.PACKAGE_VERSION]: packageVersion,
@@ -112,10 +112,10 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
   );
 
   if (traceContext.customContext) {
-    api.addContext(traceContext.customContext);
+    api.addTraceContext(traceContext.customContext);
   }
 
-  if (!trace) {
+  if (!rootSpan) {
     // sampler has decided that we shouldn't trace this request
     next();
     return;
@@ -131,27 +131,27 @@ const getMagicMiddleware = ({ userContext, traceIdSource, parentIdSource, packag
 
     let userEventContext = traceUtil.getUserContext(userContext, req);
     if (userEventContext) {
-      api.addContext(userEventContext);
+      rootSpan.addContext(userEventContext);
     }
 
-    api.addContext({
+    rootSpan.addContext({
       "request.base_url": req.baseUrl,
       "response.status_code": String(response.statusCode),
     });
     if (req.route) {
-      api.addContext({
+      rootSpan.addContext({
         "request.route": req.route.path,
       });
     }
     if (req.params) {
       Object.keys(req.params).forEach(param =>
-        api.addContext({
+        rootSpan.addContext({
           [`request.param.${param}`]: req.params[param],
         })
       );
     }
 
-    api.finishTrace(trace);
+    api.finishTrace(rootSpan);
   });
 
   onHeaders(res, function() {

--- a/lib/instrumentation/express.test.js
+++ b/lib/instrumentation/express.test.js
@@ -38,10 +38,6 @@ describe("userContext", () => {
       .expect(200, () => {
         expect(api._apiForTesting().sentEvents.length).toBe(1);
         let ev = api._apiForTesting().sentEvents[0];
-        expect(ev.startTime).not.toBeUndefined();
-        expect(ev.startTimeHR).not.toBeUndefined();
-        delete ev.startTime;
-        delete ev.startTimeHR;
         expect(ev).toEqual(
           expect.objectContaining({
             [schema.TRACE_ID]: 0,
@@ -133,7 +129,7 @@ describe("userContext as function", () => {
   });
 });
 
-describe("req proprties should only be read after a request matches a route", () => {
+describe("req properties should only be read after a request matches a route", () => {
   const express = instrumentExpress(require("express"), {});
 
   let server;
@@ -189,8 +185,10 @@ describe("req proprties should only be read after a request matches a route", ()
   });
 });
 
-describe("request id from http headers", () => {
-  const express = instrumentExpress(require("express"), {});
+describe("request id from x-request-id http header", () => {
+  const express = instrumentExpress(require("express"), {
+    traceIdSource: api.REQUEST_ID_HTTP_HEADER,
+  });
 
   let server;
   function initializeTestServer() {
@@ -224,6 +222,32 @@ describe("request id from http headers", () => {
         done();
       });
   });
+});
+
+describe("Trace ids from X-Amzn-trace-id header", () => {
+  const express = instrumentExpress(require("express"), {
+    traceIdSource: api.AMAZON_TRACE_HTTP_HEADER,
+  });
+
+  let server;
+  function initializeTestServer() {
+    let app = express();
+    app.get("/", function(req, res) {
+      // don't add req.user here
+      res.status(200).send("ok");
+    });
+
+    server = app.listen(3000);
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    initializeTestServer();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    server.close();
+  });
 
   test("X-Amzn-Trace-Id works", done => {
     request(server)
@@ -232,10 +256,36 @@ describe("request id from http headers", () => {
       .expect(200, () => {
         expect(api._apiForTesting().sentEvents.length).toBe(1);
         let ev = api._apiForTesting().sentEvents[0];
-        expect(ev[schema.TRACE_ID]).toBe("Root=1-67891233-abcdef012345678912345678");
+        expect(ev[schema.TRACE_ID]).toBe("1-67891233-abcdef012345678912345678");
         expect(ev[schema.TRACE_ID_SOURCE]).toBe("X-Amzn-Trace-Id http header");
         done();
       });
+  });
+});
+
+describe("Trace ids from X-Request-ID and X-Amzn-trace-id headers", () => {
+  const express = instrumentExpress(require("express"), {
+    traceIdSource: api.REQUEST_ID_HTTP_HEADER,
+  });
+
+  let server;
+  function initializeTestServer() {
+    let app = express();
+    app.get("/", function(req, res) {
+      // don't add req.user here
+      res.status(200).send("ok");
+    });
+
+    server = app.listen(3000);
+  }
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+    initializeTestServer();
+  });
+  afterEach(() => {
+    api._resetForTesting();
+    server.close();
   });
 
   test("X-Request-ID > X-Amzn-Trace-Id", done => {

--- a/lib/instrumentation/fastify.js
+++ b/lib/instrumentation/fastify.js
@@ -48,6 +48,23 @@ const instrumentFastify = function(fastify, opts = {}) {
   const trackedByRequest = new Map();
   const finishersByRequest = new Map();
 
+  // we only wrap the hooks that deal with requests.  we should look into wrapping the non request/reply hooks at
+  // some point.
+  const wrappedHookNames = [
+    "onRequest",
+    "preParsing",
+    "preValidation",
+    "preHandler",
+    "preSerialization",
+    "onError",
+    "onSend",
+    // TODO(toshok):
+    // we need to skip onResponse hooks, because by the time this hook is invoked, we will have already ended the
+    // trace.  There may be a way to instrument these (we'd need to end the trace after onResponse) - we should
+    // figure it out.
+    // "onResponse",
+  ];
+
   const wrapper = function(...args) {
     const app = fastify(...args);
 
@@ -58,7 +75,7 @@ const instrumentFastify = function(fastify, opts = {}) {
       if (parentTraceId) {
         traceContext.parentSpanId = parentTraceId;
       }
-      let trace = api.startTrace(
+      let rootSpan = api.startTrace(
         {
           [schema.EVENT_TYPE]: "fastify",
           [schema.PACKAGE_VERSION]: opts.packageVersion,
@@ -78,10 +95,10 @@ const instrumentFastify = function(fastify, opts = {}) {
       );
 
       if (traceContext.customContext) {
-        api.addContext(traceContext.customContext);
+        api.addTraceContext(traceContext.customContext);
       }
 
-      if (!trace) {
+      if (!rootSpan) {
         // sampler has decided that we shouldn't trace this request
         next();
         return;
@@ -90,21 +107,21 @@ const instrumentFastify = function(fastify, opts = {}) {
       const boundFinisher = api.bindFunctionToTrace(reply => {
         let userEventContext = traceUtil.getUserContext(userContext, request);
         if (userEventContext) {
-          api.addContext(userEventContext);
+          rootSpan.addContext(userEventContext);
         }
 
-        api.addContext({
+        rootSpan.addContext({
           "response.status_code": String(reply.res.statusCode),
         });
         if (request.params) {
           Object.keys(request.params).forEach(param =>
-            api.addContext({
+            rootSpan.addContext({
               [`request.param.${param}`]: request.params[param],
             })
           );
         }
 
-        api.finishTrace(trace);
+        api.finishTrace(rootSpan);
       });
 
       finishersByRequest.set(request, boundFinisher);
@@ -116,6 +133,8 @@ const instrumentFastify = function(fastify, opts = {}) {
     app.addHook("onResponse", (request, reply, next) => {
       // calculate total time for the request and send the root span
       const finisher = finishersByRequest.get(request);
+      finishersByRequest.delete(request);
+      trackedByRequest.delete(request);
       if (finisher) {
         finisher(reply);
       }
@@ -127,9 +146,7 @@ const instrumentFastify = function(fastify, opts = {}) {
     // others will show up as spans in the trace.
     shimmer.wrap(app, "addHook", function instrumentAddHook(original) {
       return function(hookName, hookFn) {
-        if (hookName == "onResponse") {
-          // we need to skip onResponse hooks, because we will have already ended the
-          // trace.  we need a way to manipulate onResponse hooks
+        if (wrappedHookNames.indexOf(hookName) === -1) {
           return original.apply(this, [hookName, hookFn]);
         }
 
@@ -137,6 +154,10 @@ const instrumentFastify = function(fastify, opts = {}) {
           let request = args[0];
 
           let tracked = trackedByRequest.get(request);
+          if (!tracked) {
+            return hookFn.apply(this, args);
+          }
+
           tracker.setTracked(tracked);
 
           let span = api.startSpan({

--- a/lib/instrumentation/fastify.test.js
+++ b/lib/instrumentation/fastify.test.js
@@ -36,16 +36,6 @@ describe("userContext", () => {
           const sentEvents = api._apiForTesting().sentEvents;
           expect(sentEvents.length).toBe(2);
 
-          expect(sentEvents[0].startTime).not.toBeUndefined();
-          expect(sentEvents[0].startTimeHR).not.toBeUndefined();
-          delete sentEvents[0].startTime;
-          delete sentEvents[0].startTimeHR;
-
-          expect(sentEvents[1].startTime).not.toBeUndefined();
-          expect(sentEvents[1].startTimeHR).not.toBeUndefined();
-          delete sentEvents[1].startTime;
-          delete sentEvents[1].startTimeHR;
-
           expect(sentEvents).toEqual(
             expect.arrayContaining([
               expect.objectContaining({
@@ -91,12 +81,14 @@ describe("userContext", () => {
       name: "field array userContext",
       userContext: ["id", "username"],
       packageVersion: "1.1.1",
+      traceIdSource: api.REQUEST_ID_HTTP_HEADER,
     },
 
     {
       description: "function userContext",
       userContext: req => ({ id: req.user.id, username: req.user.username }),
       packageVersion: "1.1.1",
+      traceIdSource: api.REQUEST_ID_HTTP_HEADER,
     },
   ]);
 });
@@ -142,7 +134,7 @@ describe("userContext as function", () => {
 
 describe("request id from http headers", () => {
   function runCase(opts, done) {
-    const fastify = instrumentFastify(require("fastify"));
+    const fastify = instrumentFastify(require("fastify"), { traceIdSource: opts.traceIdSource });
     expect(fastify.__wrapped).toBe(true);
 
     function initializeTestServer() {
@@ -189,15 +181,15 @@ describe("request id from http headers", () => {
       headers: [{ name: "X-Request-ID", value: "abc123" }],
       expectedHeaderName: "X-Request-ID",
       expectedHeaderValue: "abc123",
+      traceIdSource: api.REQUEST_ID_HTTP_HEADER,
     },
-
     {
       name: "X-Request-ID works",
       headers: [{ name: "X-Amzn-Trace-Id", value: "Root=1-67891233-abcdef012345678912345678" }],
       expectedHeaderName: "X-Amzn-Trace-Id",
-      expectedHeaderValue: "Root=1-67891233-abcdef012345678912345678",
+      expectedHeaderValue: "1-67891233-abcdef012345678912345678",
+      traceIdSource: api.AMAZON_TRACE_HTTP_HEADER,
     },
-
     {
       name: "X-Request-ID > X-Amzn-Trace-Id",
       headers: [
@@ -206,6 +198,7 @@ describe("request id from http headers", () => {
       ],
       expectedHeaderName: "X-Request-ID",
       expectedHeaderValue: "abc123",
+      traceIdSource: api.REQUEST_ID_HTTP_HEADER,
     },
   ]);
 });

--- a/lib/instrumentation/mongodb.js
+++ b/lib/instrumentation/mongodb.js
@@ -51,10 +51,15 @@ function instrumentMongodb(mongodb, opts = {}) {
           },
           span => {
             if (options) {
-              api.addContext(prefixKeys("db.options", options));
+              span.addContext(
+                prefixKeys("db.options", {
+                  ...options,
+                  session: undefined,
+                })
+              );
             }
             if (additionalContext) {
-              api.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
+              span.addContext(prefixKeys("db", additionalContext(...populatedArgs)));
             }
 
             if (callback) {
@@ -75,7 +80,7 @@ function instrumentMongodb(mongodb, opts = {}) {
                 },
                 err => {
                   if (err) {
-                    api.addContext({ error: err.toString() });
+                    span.addContext({ error: err.toString() });
                   }
                   api.finishSpan(span, eventName);
                 }

--- a/lib/instrumentation/pg.js
+++ b/lib/instrumentation/pg.js
@@ -3,21 +3,55 @@ const shimmer = require("shimmer"),
   api = require("../api"),
   schema = require("../schema");
 
-const getQueryString = function(args) {
-  if (typeof args[0] === "string") return args[0];
-  if (typeof args[0] === "object") return args[0].text;
+const getQueryString = function([config]) {
+  if (typeof config === "string") return config;
+  if (typeof config === "object") {
+    if (typeof config.cursor === "object") {
+      return config.cursor.text;
+    }
+    return config.text;
+  }
   return undefined;
 };
 
-const getQueryArgs = function(args) {
-  if (typeof args[0] === "object") return args[0].values;
-  if (Array.isArray(args[1])) return args[1];
+const getQueryArgs = function([config, values]) {
+  if (typeof config === "object") {
+    if (typeof config.cursor === "object") {
+      return config.cursor.values;
+    }
+    return config.values;
+  }
+  if (Array.isArray(values)) return values;
   return undefined;
 };
 
-const getQueryName = function(args) {
-  if (typeof args[0] === "object") return args[0].name;
+const getQueryName = function([config]) {
+  if (typeof config === "object") return config.name;
   return undefined;
+};
+
+const wrapper = (span, cb) => {
+  return api.bindFunctionToTrace((...cb_args) => {
+    const [error, result] = cb_args;
+
+    if (error !== null && error instanceof Error) {
+      span.addContext({
+        "db.error": error.message,
+        "db.error_stack": error.stack,
+        "db.error_hint": error.hint,
+      });
+    }
+
+    if (result) {
+      span.addContext({
+        "db.rows_affected": result.rowCount,
+      });
+    }
+
+    api.finishSpan(span, "query");
+
+    return cb(...cb_args);
+  });
 };
 
 let instrumentPg = function(pg, opts = {}) {
@@ -40,32 +74,32 @@ let instrumentPg = function(pg, opts = {}) {
           "db.query_name": getQueryName(args),
         },
         span => {
-          let cb = args[args.length - 1];
-          // XXX(toshok) this bindFunction shouldn't be necessary, but we aren't
-          // finishing the event properly without it.
-          let wrapped_cb = api.bindFunctionToTrace(function(...cb_args) {
-            let error = cb_args[0];
-            let result = cb_args[1];
-
-            if (error !== null && error instanceof Error) {
-              api.addContext({
-                "db.error": error.message,
-                "db.error_stack": error.stack,
-                "db.error_hint": error.hint,
-              });
+          let [config, values, callback] = args;
+          // we could be given the following:
+          // query string, values, callback
+          // query string, callback
+          // Query object
+          // Query object, callback
+          if (typeof config.submit === "function") {
+            // we have a 'Query' like object
+            if (config.callback) {
+              config.callback = wrapper(span, config.callback);
+            } else if (typeof values === "function") {
+              values = wrapper(span, values);
+            } else {
+              if (typeof config.on === "function") {
+                config.on("close", wrapper(span, () => {}));
+              }
             }
-
-            if (result) {
-              api.addContext({
-                "db.rows_affected": result.rowCount,
-              });
+          } else {
+            if (typeof callback === "function") {
+              callback = wrapper(span, callback);
+            } else if (typeof values === "function") {
+              values = wrapper(span, values);
             }
+          }
 
-            api.finishSpan(span, "query");
-            return cb(...cb_args);
-          });
-
-          return query.apply(this, args.slice(0, -1).concat(wrapped_cb));
+          return query.apply(this, [config, values, callback]);
         }
       );
     };

--- a/lib/instrumentation/pg.test.js
+++ b/lib/instrumentation/pg.test.js
@@ -1,0 +1,80 @@
+/* eslint-env node, jest */
+const api = require("../api"),
+  instrumentPG = require("./pg"),
+  QueryStream = require("pg-query-stream");
+
+const pg = instrumentPG(require("pg"));
+
+describe("pg", () => {
+  const callback = (client, trace, done) => {
+    return () => {
+      client.end();
+      const events = api._apiForTesting().sentEvents;
+      const event = events.find(e => e.name === "query");
+      expect(event).toMatchObject({
+        "db.query": expect.any(String),
+      });
+      done();
+    };
+  };
+
+  beforeEach(() => {
+    api.configure({ impl: "mock" });
+  });
+
+  afterEach(() => {
+    api._resetForTesting();
+  });
+
+  test("basic query with callback", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    client.query("SELECT 1;", callback(client, trace, done));
+    api.finishTrace(trace);
+  });
+
+  test("basic query with values and callback", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    client.query("select $1::text as name;", ["honeycomb"], callback(client, trace, done));
+    api.finishTrace(trace);
+  });
+
+  test("query config object with callback", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    const query = {
+      text: "select $1::text as name;",
+      values: ["honeycomb"],
+    };
+    client.query(query, callback(client, trace, done));
+    api.finishTrace(trace);
+  });
+
+  test("query object with internal callback", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    const query = new pg.Query(
+      "select $1::text as name",
+      ["brianc"],
+      callback(client, trace, done)
+    );
+    client.query(query);
+    api.finishTrace(trace);
+  });
+
+  test("pg-query-stream", done => {
+    const trace = api.startTrace({ name: "pg-test" });
+    const client = new pg.Client();
+    client.connect();
+    const query = new QueryStream("SELECT * FROM generate_series(0, $1) num", [10]);
+    const stream = client.query(query);
+    stream.on("close", callback(client, trace, done));
+    stream.on("readable", stream.read);
+    api.finishTrace(trace);
+  });
+});

--- a/lib/instrumentation/trace-util.js
+++ b/lib/instrumentation/trace-util.js
@@ -25,7 +25,7 @@ exports.getTraceContext = (traceIdSource, req) => {
   if (typeof traceIdSource === "undefined" || typeof traceIdSource === "string") {
     let headers =
       typeof traceIdSource === "undefined"
-        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", "X-Amzn-Trace-Id"]
+        ? [api.TRACE_HTTP_HEADER, "X-Request-ID", api.AMAZON_TRACE_HTTP_HEADER]
         : [traceIdSource];
     let valueAndHeader = getValueFromHeaders(req.headers, headers);
 
@@ -43,6 +43,35 @@ exports.getTraceContext = (traceIdSource, req) => {
         return Object.assign({}, parsed, {
           source: `${header} http header`,
         });
+      }
+
+      case api.AMAZON_TRACE_HTTP_HEADER: {
+        let traceId, parentSpanId;
+
+        const split = value.split(";");
+        for (const s of split) {
+          const [name, value] = s.split("=");
+          if (name === "Root") {
+            traceId = value;
+          } else if (name === "Parent") {
+            parentSpanId = value;
+          }
+        }
+
+        if (!traceId) {
+          // if we didn't even get a 'Root=' clause, bail.
+          return {};
+        }
+
+        if (!parentSpanId) {
+          parentSpanId = traceId;
+        }
+
+        return {
+          traceId,
+          parentSpanId,
+          source: `${header} http header`,
+        };
       }
 
       default: {
@@ -66,7 +95,7 @@ exports.getParentSourceId = (parentIdSource, req) => {
   } else if (typeof traceIdSource === "function") {
     return parentIdSource(req);
   }
-};  
+};
 
 exports.getUserContext = (userContext, req) => {
   if (!userContext) {

--- a/lib/instrumentation/trace-util.test.js
+++ b/lib/instrumentation/trace-util.test.js
@@ -1,0 +1,90 @@
+/* eslint-env node, jest */
+const cases = require("jest-in-case"),
+  http = require("http"),
+  api = require("../api"),
+  traceUtil = require("./trace-util");
+
+function getRequestWithHeader(name, value) {
+  const req = new http.IncomingMessage();
+  req.headers[name.toLowerCase()] = value;
+  return req;
+}
+
+describe("getTraceContext", () => {
+  cases(
+    "AWS X-Ray trace header",
+    opts => {
+      expect(
+        traceUtil.getTraceContext(
+          "X-Amzn-Trace-Id",
+          getRequestWithHeader("X-Amzn-Trace-Id", opts.headerVal)
+        )
+      ).toEqual(opts.expectedContext);
+    },
+    [
+      {
+        name: "root / no parent",
+        headerVal: "Root=1-67891233-abcdef012345678912345678",
+        expectedContext: {
+          traceId: "1-67891233-abcdef012345678912345678",
+          parentSpanId: "1-67891233-abcdef012345678912345678",
+          source: "X-Amzn-Trace-Id http header",
+        },
+      },
+      {
+        name: "root / parent",
+        headerVal: "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8",
+        expectedContext: {
+          traceId: "1-5759e988-bd862e3fe1be46a994272793",
+          parentSpanId: "53995c3f42cd8ad8",
+          source: "X-Amzn-Trace-Id http header",
+        },
+      },
+      {
+        name: "self / root / no parent",
+        headerVal:
+          "Self=1-5983f5c9-36d365bc453d28036a63032b;Root=1-5983f5c9-56dcf0bc6d4d214d2dbbe8c6",
+        expectedContext: {
+          parentSpanId: "1-5983f5c9-56dcf0bc6d4d214d2dbbe8c6",
+          traceId: "1-5983f5c9-56dcf0bc6d4d214d2dbbe8c6",
+          source: "X-Amzn-Trace-Id http header",
+        },
+      },
+      {
+        // shouldn't happen at least with aws generated headers, but if we're missing a Root= clause, we aren't in a trace at all.
+        name: "no root / parent",
+        headerVal: "Parent=53995c3f42cd8ad8",
+        expectedContext: {},
+      },
+    ]
+  );
+  cases(
+    "beeline trace header",
+    opts => {
+      expect(
+        traceUtil.getTraceContext(
+          undefined,
+          getRequestWithHeader(api.TRACE_HTTP_HEADER, opts.headerVal)
+        )
+      ).toEqual(opts.expectedContext);
+    },
+    [
+      {
+        name: "v1 trace_id + parent_id, missing context",
+        headerVal: "1;trace_id=abcdef,parent_id=12345",
+        expectedContext: {
+          traceId: "abcdef",
+          parentSpanId: "12345",
+          customContext: undefined,
+          dataset: undefined,
+          source: "X-Honeycomb-Trace http header",
+        },
+      },
+      {
+        name: "v1, missing trace_id",
+        contextStr: "1;parent_id=12345",
+        expectedContext: {},
+      },
+    ]
+  );
+});

--- a/lib/propagation.js
+++ b/lib/propagation.js
@@ -5,6 +5,8 @@ const path = require("path"),
   schema = require("./schema");
 
 exports.TRACE_HTTP_HEADER = "X-Honeycomb-Trace";
+exports.AMAZON_TRACE_HTTP_HEADER = "X-Amzn-Trace-Id";
+exports.REQUEST_ID_HTTP_HEADER = "X-Request-ID";
 
 const VERSION = "1";
 exports.VERSION = VERSION;
@@ -26,11 +28,11 @@ exports.VERSION = VERSION;
 // ex: X-Honeycomb-Trace: 1;trace_id=weofijwoeifj,parent_id=owefjoweifj,context=SGVsbG8gV29ybGQ=
 
 exports.marshalTraceContext = marshalTraceContextv1;
-function marshalTraceContextv1(traceContext) {
-  let traceId = traceContext.id;
-  let spanId = traceContext.stack[traceContext.stack.length - 1][schema.TRACE_SPAN_ID];
-  let contextToSend = traceContext.customContext || {};
-  let dataset = traceContext.dataset;
+function marshalTraceContextv1(context) {
+  let traceId = context.id;
+  let spanId = context.stack[context.stack.length - 1].payload[schema.TRACE_SPAN_ID];
+  let contextToSend = context.traceContext || {};
+  let dataset = context.dataset;
 
   let datasetClause = "";
   if (dataset) {
@@ -59,7 +61,7 @@ function unmarshalTraceContextv1(payload) {
   let traceId, parentSpanId, dataset, contextb64;
 
   clauses.forEach(cl => {
-    let [k, v] = cl.split("=");
+    let [k, v] = cl.split("=", 2);
     switch (k) {
       case "trace_id":
         traceId = v;

--- a/lib/propagation.test.js
+++ b/lib/propagation.test.js
@@ -1,14 +1,15 @@
 /* global require describe test expect */
 const propagation = require("./propagation"),
   schema = require("./schema"),
+  Span = require("./api/span"),
   cases = require("jest-in-case");
 
 // this context structure is the same as what the libhoney event api implementation generate.
 let testContext = {
   id: "abcdef123456",
   dataset: "testDataset",
-  stack: [{ [schema.TRACE_SPAN_ID]: "0102030405" }],
-  customContext: {
+  stack: [new Span({ [schema.TRACE_SPAN_ID]: "0102030405" })],
+  traceContext: {
     userID: 1,
     errorMsg: "failed to sign on",
     toRetry: true,
@@ -61,6 +62,17 @@ cases(
       value: {
         traceId: "abcdef",
         parentSpanId: "12345",
+      },
+    },
+    {
+      name: "v1, with context",
+      contextStr: "1;trace_id=abcdef,parent_id=12345,context=eyJmb28iOiJiYXIifQo=",
+      value: {
+        traceId: "abcdef",
+        parentSpanId: "12345",
+        customContext: {
+          foo: "bar",
+        },
       },
     },
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-beeline",
-  "version": "1.8.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,7 +8,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -50,7 +49,6 @@
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
       "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
@@ -62,7 +60,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -73,7 +70,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -88,7 +84,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -108,7 +103,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -118,16 +112,14 @@
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         }
       }
     },
     "@babel/parser": {
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-      "dev": true
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A=="
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
@@ -151,7 +143,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.6.0",
@@ -162,7 +153,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
       "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.6.3",
@@ -179,7 +169,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -190,7 +179,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
       "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
@@ -566,9 +554,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-globals": {
@@ -579,14 +567,6 @@
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
-          "dev": true
-        }
       }
     },
     "acorn-jsx": {
@@ -637,7 +617,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -800,6 +779,19 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -1099,6 +1091,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1185,7 +1183,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.1.0",
         "escape-string-regexp": "^1.0.5",
@@ -1350,7 +1347,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -1358,8 +1354,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1828,8 +1823,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.1",
@@ -1943,8 +1937,7 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "5.0.1",
@@ -1955,14 +1948,6 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -3274,8 +3259,7 @@
     "globals": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
-      "dev": true
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
     },
     "globby": {
       "version": "6.1.0",
@@ -3375,8 +3359,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4796,13 +4779,20 @@
         "whatwg-url": "^6.4.1",
         "ws": "^5.2.0",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        }
       }
     },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -4900,10 +4890,11 @@
       }
     },
     "libhoney": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-2.0.1.tgz",
-      "integrity": "sha512-IA0c6laJIMFxXThrPXbzdGVUtboacYB9x1FSPMVle4yrnMQ4LSbQIlTrwQcy4zl9BsaoKjxik56zVHpojflupA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-2.0.2.tgz",
+      "integrity": "sha512-qFUE33bbKySonx98bDdPalCGlhA3oBvSVEVuvwvbtEKaI45seHh/IM9nPapsJqdko8Eo5+WS1GKdkMPbz+m2Yg==",
       "requires": {
+        "babel-eslint": "^10.0.3",
         "superagent": "^3.8.3",
         "superagent-proxy": "^2.0.0",
         "urljoin": "^0.1.5"
@@ -5193,8 +5184,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5860,6 +5850,12 @@
         "thunkify": "^2.1.2"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
@@ -5932,8 +5928,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -5955,6 +5950,84 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "pg": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.14.0.tgz",
+      "integrity": "sha512-TLsdOWKFu44vHdejml4Uoo8h0EwCjdIj9Z9kpz7pA5i8iQxOTwVb1+Fy+X86kW5AXKxQpYpYDs4j/qPDbro/lg==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "^2.0.7",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
+    },
+    "pg-cursor": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.0.1.tgz",
+      "integrity": "sha512-AfPaRh6N32HrXB8/D0JXfJWdLCn8U+Z4LEf8C954aSFTjhZqt7QbyAYyN5k1E4cv0HQjwW70G1xywQ5ZECzPPg==",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw==",
+      "dev": true
+    },
+    "pg-query-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-2.0.1.tgz",
+      "integrity": "sha512-yiAbAkZHe3lgoQt0BdhqVe0KJ2ggB9yAUzpiNrbRpvolBMFIeO/RNsbR+V3Opigk2YiXNc1rjsTHLAd0Sj1iMg==",
+      "dev": true,
+      "requires": {
+        "pg-cursor": "^2.0.1"
+      }
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "^1.0.0"
+      }
     },
     "pify": {
       "version": "3.0.0",
@@ -6035,6 +6108,33 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6282,9 +6382,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6463,7 +6563,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -6807,9 +6906,9 @@
       }
     },
     "smart-buffer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -6929,12 +7028,12 @@
       }
     },
     "socks": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
-      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "4.0.2"
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
       }
     },
     "socks-proxy-agent": {
@@ -6968,8 +7067,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.1",
@@ -7039,6 +7137,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -7333,7 +7440,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "dev": true,
       "requires": {
         "has-flag": "^2.0.0"
       }
@@ -7471,8 +7577,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -7947,6 +8052,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "automatic instrumentation for honeycomb.io",
   "author": "support@honeycomb.io",
   "license": "Apache-2.0",
-  "version": "1.8.3",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/honeycombio/beeline-nodejs.git"
@@ -35,6 +35,8 @@
     "jest": "^24.9.0",
     "jest-in-case": "^1.0.2",
     "lint-staged": "^8.1.5",
+    "pg": "^7.14.0",
+    "pg-query-stream": "^2.0.1",
     "prettier": "^1.16.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
@@ -44,7 +46,7 @@
   "dependencies": {
     "array-flatten": "^2.1.2",
     "debug": "^4.1.1",
-    "libhoney": "^2.0.1",
+    "libhoney": "^2.0.2",
     "on-headers": "^1.0.2",
     "shimmer": "^1.2.1",
     "uuid": "^3.3.2"


### PR DESCRIPTION
* Don't capture MongoDB session objects (#174)

* Don't capture MongoDB session objects

The MongoDB session object is passed into some calls as `options.session` and cannot be serialised to JSON, thus crashing the instrumentation.

Fixes #157

* Fix modification to parameters

I realised the previous fix would modify the parameter object `options` which might not be desired (or might be problematic). This version instead omits the `session` property from it when passing to `prefixKeys` instead of directly modifying the object.

* Remove old code

* PG instrumentation callbacks (#175)

Try to better handle the arguments being passed to the `query` function. It looks like having these three arguments have been pretty stable for many years. 

We need to decipher where in the arguments the callback lives. From reading the source, it looks like the options are these:

// query string, values, callback
// query string, callback
// Query like object
// Query like object, callback

Once we have deciphered where the correct callback lives we wrap it and pass it onto the wrapped `query` function.

This seems to work in my local manual testing. Looking into how to add some unit tests for this as well.

Resolves #173.

* 1.8.4

* Add lint step & fix lint error (#176)

Previously we only ran the lint step as part of the publish step which meant that any lint errors would block publishing.

This creates a new job that performs the linting before any of the test steps runs and removes the lint from the publish step.

In order to fix the existing lint error we had to set the ecma version to 2018.

* 1.8.5

* Everything must have filters :rage1:

* 1.8.6

* bump libhoney dep to ^2.0.2 (#178)

Bring in 2.0.2 of libhoney (https://github.com/honeycombio/libhoney-js/releases/tag/2.0.2) which drops (locally) `require()` time for the beeline from ~170ms to ~50ms.

Also take this time to drop documented support non-LTS node versions.

* 2.0.0

* [fastify] only wrap the request/reply hooks (#180)

Add a whitelist for request/reply hooks (https://github.com/fastify/fastify/blob/master/docs/Hooks.md), and just pass the others through unshimmed (the shim code assumes we're dealing with those hooks currently.)

Also make things a bit more robust by not crashing if there are requests that somehow didn't start a trace.

* 2.0.1

* [From geckoboard] fix errors when not in a trace (#181)

* Stop the beeline crashing if running outside of a trace

* Ensure we invoke async spans if the parent context isn't valid

Co-authored-by: Matt Button <matt.button@geckoboard.com>

* Remove entries from previously unbounded maps (#183)

* The request is safe to delete from finishersByRequest because
it is accessed only once, on the previous line, so long as there
is only one 'onResponse' per request.
* The request is safe to delete from trackedByRequest because
onResponse is the last available hook in the lifecycle.

* 2.0.2

* Bump acorn from 5.7.3 to 5.7.4 (#185)

* clean up a bunch of span/context related hacks and bugs (#184)

A few things changed here - one thing in a backward incompatible way _but_ in a way consistent with our docs.

1. Introduce a `Span` class, and change the api implementations to use instances of `Span` instead of regular JS objects in their `context.stack`.
2. `Span` exposes an `addContext` method that acts similar to the go beeline's -- no prefixing of `app.` when using it.  Change all instrumentation to call this method directly, since we always have a span there.
3. `Span` also has fields for `startTime`/`startTimeHR` so all the handling of those fields can be cleaned up - no more `delete`ing them from the payload when we send (and in tests!  ugh.)
3. Add a toplevel `addTraceContext` api method that acts similar to the go beeline's -- prefix with `app.` and also propagates to outbound http/https.
4. The backward incompatible change alluded to above: `api.addContext` no longer results in that context being propagated to outbound calls.  This is the documented behavior, so I don't feel as bad about making this change.

Now for the good stuff.  This PR also marks some things as deprecated or to-be-changed with the next major bump:

1. `api.customContext.{add, remove}` goes away entirely.  `.add` is the same as `api.addTraceContext`.  there is no replacement for `.remove`
2. similarly, `api.removeContext` goes away without replacement.
3. `api.addContext` will prefix with `app.`.  This mirrors the go beeline - if you have direct reference to a span you can call `span.addContext` and it won't prepend `app.`.  If you call the toplevel `addContext`, it will.

Added some more tests that exercise the various context adding methods so we'll fail those if we have regressions again in any of the documented behavior.

Fixes #149 
Fixes #156 
maybe others...

* parse AWS trace header (#187)

We care about Root/Parent clauses currently, and map those to traceId/parentSpanId.

This code matches the behavior of code aws uses in their sdks.

We'll need to figure out how propagation works in the aws world (on outbound requests) so we can add our custom stuff there as well, which will in turn cause more changes to this code.

algorithm for dealing with the header is basically:

1. split aws header by `;`
2. walk the list of strings from #1, splitting each string by `=` into [key, value].
    2a. if we see key="Root", value becomes traceId.
    2b. if we see key="Parent", value becomes parentSpanId.
3. If we didn't see traceId, bail.
4. If we didn't see parentSpanId, fall back to traceId.

* 2.1.0

* split('=') needs max=2 or we break base64 encoded context with padding (#191)

Fixes #190 

Splitting `k=v` strings by `=` fails if `v` contains an `=`, which is quite likely given that we're base64 encoding our trace `context`.  use `.split("=", 2)` to fix.

* Test that non-Honeycomb header trace parsing is configurable. (#194)

Make header constants consistent. Add tests for setting traceIdSource explicitly in the express of fastify initialization code. Users who do not want automatic parsing of incoming Amazon trace ID headers or Request IDs should now specify a traceIdSource in their initialization code to prevent missing root spans.

```
require("honeycomb-beeline")({
    writeKey:    "foo",
    dataset:     "bar",
    serviceName: "foo-service",
    express: {
        traceIdSource: 'X-Amzn-Trace-Id',
    },
})
```

In the next major release, we'll make this behavior the default (only Honeycomb headers will be parsed unless another header format is explicitly specified).

Co-authored-by: James Ross <twpol@users.noreply.github.com>
Co-authored-by: Martin Holman <martin@honeycomb.io>
Co-authored-by: Martin Holman <me@martinholman.co.nz>
Co-authored-by: Chris Toshok <toshok@hound.sh>
Co-authored-by: Chris Toshok <toshok@gmail.com>
Co-authored-by: Matt Button <matt.button@geckoboard.com>
Co-authored-by: Cameron Dunn <60160513+camerondunn-ns8@users.noreply.github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Paul Osman <paul@honeycomb.io>